### PR TITLE
Fix drag and drop functionality on macOS

### DIFF
--- a/src/lib/shared/drag.svelte.ts
+++ b/src/lib/shared/drag.svelte.ts
@@ -1,0 +1,123 @@
+import { startDrag } from "@crabnebula/tauri-plugin-drag"
+import { join, appCacheDir } from "@tauri-apps/api/path"
+import { exists, create, mkdir, readFile } from "@tauri-apps/plugin-fs"
+import { saveSample, savePackImage, absolutePackImagePath } from "./files.svelte"
+import { loading } from "./loading.svelte"
+import type { SampleAsset, PackAsset } from "$lib/splice/types"
+
+async function createDragIcon(
+    packImagePath: string,
+    packId: string
+): Promise<string> {
+    const cacheDir = await appCacheDir()
+    const iconPath = await join(cacheDir, `${packId}.png`)
+
+    if (!(await exists(iconPath))) {
+        // Ensure cache directory exists
+        if (!(await exists(cacheDir))) {
+            await mkdir(cacheDir)
+        }
+
+        // Read the saved pack image file
+        const imageData = await readFile(packImagePath)
+        const buffer = new ArrayBuffer(imageData.byteLength)
+        const view = new Uint8Array(buffer)
+        view.set(imageData)
+        const resizedImageData = await resizeImageToCorner(buffer)
+        const file = await create(iconPath)
+        await file.write(resizedImageData)
+        await file.close()
+    }
+
+    return iconPath
+}
+
+async function createInvisibleIcon(): Promise<string> {
+    const cacheDir = await appCacheDir()
+    const iconPath = await join(cacheDir, "invisible-drag-icon.png")
+
+    if (!(await exists(iconPath))) {
+        if (!(await exists(cacheDir))) {
+            await mkdir(cacheDir)
+        }
+
+        const transparentPng = new Uint8Array([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+            0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+            0x0b, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x02, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+            0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+        ])
+
+        const file = await create(iconPath)
+        await file.write(transparentPng)
+        await file.close()
+    }
+
+    return iconPath
+}
+
+async function resizeImageToCorner(
+    imageBuffer: ArrayBuffer
+): Promise<Uint8Array> {
+    return new Promise((resolve) => {
+        const blob = new Blob([imageBuffer])
+        const img = new Image()
+        const iconSize = 64
+        img.onload = () => {
+            const canvasWidth = iconSize * 2
+            const canvasHeight = iconSize * 2.5
+            const canvas = document.createElement("canvas")
+            const ctx = canvas.getContext("2d")!
+
+            canvas.width = canvasWidth
+            canvas.height = canvasHeight
+
+            // Transparent background
+            ctx.clearRect(0, 0, canvasWidth, canvasHeight)
+
+            // Position the image in the top-right corner of the canvas
+            const x = canvasWidth - iconSize
+            const y = 0
+
+            ctx.drawImage(img, x, y, iconSize, iconSize)
+
+            canvas.toBlob((blob) => {
+                blob!.arrayBuffer().then((buffer) => {
+                    resolve(new Uint8Array(buffer))
+                })
+            }, "image/png")
+        }
+        img.src = URL.createObjectURL(blob)
+    })
+}
+
+export async function handleSampleDrag(event: DragEvent, sampleAsset: SampleAsset) {
+    event.preventDefault()
+    console.log("🫳 Dragging", sampleAsset.name)
+
+    try {
+        loading.setCursor(true)
+        const path = await saveSample(sampleAsset)
+
+        // Save pack image to samples directory and use it as drag icon
+        const pack = sampleAsset.parents.items[0] as PackAsset
+        let iconPath: string
+
+        const packImagePath = await savePackImage(sampleAsset)
+
+        // Check if the image exists and use it, otherwise fallback to invisible icon
+        if (await exists(packImagePath)) {
+            iconPath = await createDragIcon(packImagePath, pack.uuid)
+        } else {
+            iconPath = await createInvisibleIcon()
+        }
+
+        startDrag({ item: [path], icon: iconPath })
+    } catch (e) {
+        console.error("⚠️ Error dragging", e)
+    } finally {
+        loading.setCursor(false)
+    }
+}

--- a/src/lib/shared/files.svelte.ts
+++ b/src/lib/shared/files.svelte.ts
@@ -87,3 +87,49 @@ export async function saveSample(sampleAsset: SampleAsset) {
 
     return absolutePath
 }
+
+export async function absolutePackImagePath(sampleAsset: SampleAsset) {
+    if (!config.samples_dir) {
+        throw new Error("❌ Samples Directory not set")
+    }
+
+    if (!isSamplesDirValid()) {
+        throw new Error("❌ Samples Directory invalid")
+    }
+
+    const pack = sampleAsset.parents.items[0]
+    const packDir = sanitizePath(pack.name)
+    return await join(config.samples_dir, packDir, "cover.jpg")
+}
+
+export async function savePackImage(sampleAsset: SampleAsset) {
+    const pack = sampleAsset.parents.items[0]
+    const packImageUrl = pack?.files[0].url
+
+    const absolutePath = await absolutePackImagePath(sampleAsset)
+
+    if (!absolutePath) {
+        throw new Error("❌ Invalid path")
+    }
+
+    if (await exists(absolutePath)) {
+        console.log("🗃️ Image already exists at", absolutePath)
+        return absolutePath
+    }
+
+    const response = await fetch(packImageUrl)
+    const buffer = await response.arrayBuffer()
+
+    console.log("🖼️ Saving pack image at", absolutePath)
+
+    await ensureFileDirectoryExists(absolutePath)
+
+    const file = await create(absolutePath)
+    await file.write(new Uint8Array(buffer))
+    await file.close()
+
+    console.log("🎉 Pack image saved!")
+
+    return absolutePath
+}
+

--- a/src/routes/sample-list-entry.svelte
+++ b/src/routes/sample-list-entry.svelte
@@ -13,9 +13,8 @@
     import { dataStore, fetchAssets } from "$lib/shared/store.svelte"
     import { cn, formatKey } from "$lib/utils"
     import { loading } from "$lib/shared/loading.svelte"
-    import { saveSample } from "$lib/shared/files.svelte"
-    import { startDrag } from "@crabnebula/tauri-plugin-drag"
     import { assetIcons } from "$lib/shared/icons.svelte"
+    import {handleSampleDrag} from "$lib/shared/drag.svelte"
 
     let {
         class: className,
@@ -45,20 +44,6 @@
         var seconds = Math.floor((millis % 60000) / 1000)
         return minutes + ":" + (seconds < 10 ? "0" : "") + seconds
     }
-
-    async function handleDrag(event: DragEvent) {
-        event.preventDefault()
-        console.log("🫳 Dragging", sampleAsset.name)
-        try {
-            loading.setCursor(true)
-            const path = await saveSample(sampleAsset)
-            startDrag({ item: [path], icon: "" })
-        } catch (e) {
-            console.error("⚠️ Error dragging", e)
-        } finally {
-            loading.setCursor(false)
-        }
-    }
 </script>
 
 <button
@@ -71,7 +56,7 @@
     draggable="true"
     tabindex="-1"
     onmousedown={() => globalAudio.selectSampleAsset(sampleAsset, false)}
-    ondragstart={handleDrag}
+    ondragstart={(event) => handleSampleDrag(event, sampleAsset)}
 >
     <PackPreview {pack} />
     <Button


### PR DESCRIPTION
The `startDrag` function was receiving an empty string for the icon parameter, which prevented drag operations from working properly on Mac. This change extracts drag logic into a dedicated module and uses sample pack images as drag icons, with caching and a transparent fallback icon when pack images aren't available.

Here's a quick screen recording showing it in action:

https://github.com/user-attachments/assets/a4e94a7a-66fb-4515-b424-1e84bf25422a

