### PR TITLE
Fix macOS CORS issues

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         ],
         "security": {
             "csp": {
-                "connect-src": "'self' ipc: blob: http://ipc.localhost http://tauri.localhost https://*.splice.com/** https://spliceproduction.s3.*.amazonaws.com/** https://*.amazonaws.com/spliceblob.splice.com/**"
+                "connect-src": "'self' ipc: blob: http://ipc.localhost http://tauri.localhost https://*.splice.com/** https://spliceproduction.s3.*.amazonaws.com/** https://*.amazonaws.com/spliceblob.splice.com/** https://splice-res.cloudinary.com"
             }
         }
     },

--- a/src/lib/shared/files.svelte.ts
+++ b/src/lib/shared/files.svelte.ts
@@ -134,7 +134,8 @@ export async function savePackImage(sampleAsset: SampleAsset) {
 
         return absolutePath
     } catch (e: any) {
-        if (e instanceof TypeError && e.message.includes("Failed to fetch")) {
+        console.log(e.message)
+        if (e instanceof TypeError && (e.message.includes("Failed to fetch") || e.message.includes("Load failed"))) {
             console.warn("⚠️ CORS error or network issue when fetching pack image", e)
             return null
         }


### PR DESCRIPTION
- Fixed CORS error preventing drag functionality on macOS by adding `https://splice-res.cloudinary.com` to the CSP `connect-src` directive in `src-tauri/tauri.conf.json`. The app was unable to fetch drag icons due to CORS restrictions, causing drag and drop functionality to fail on macOS where drag icons are required for proper user interaction.

- Added `"Load failed"` error message in addition to `"Failed to fetch"` when pack image fetching fails. I guess `"Failed to fetch"` is the error message on Windows and "`Load failed"` on macOS.

Also, tested in build version to ensure the fix works in production.
