### PR TITLE
FIX: Add Apollo preflight headers to fix Splice API requests

### DIFF
--- a/src/lib/splice/api.ts
+++ b/src/lib/splice/api.ts
@@ -90,6 +90,10 @@ export async function querySplice(
         body: JSON.stringify(body),
         headers: {
             "Content-Type": "application/json",
+            "User-Agent":
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+            "apollo-require-preflight": "true",
+            "x-apollo-operation-name": body.operationName || "SamplesSearch",
         },
     })
     if (!response.ok) {


### PR DESCRIPTION
Splice's GraphQL endpoint now requires the apollo-require-preflight and x-apollo-operation-name headers (plus a browser User-Agent). Without them sample searches fail and no samples load.

Fixes #30